### PR TITLE
added debian in os vendor check

### DIFF
--- a/cmake/Modules/helperMacros.cmake
+++ b/cmake/Modules/helperMacros.cmake
@@ -78,7 +78,7 @@ function(get_python_module_install_path python_version_string install_path)
     list(GET version_list 0 major_version)
     list(GET version_list 1 minor_version)
     
-    if(("${os_vendor}" STREQUAL "Ubuntu") AND 
+    if((("${os_vendor}" STREQUAL "Ubuntu") OR ("${os_vendor}" STREQUAL "Debian")) AND 
     (("${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr") OR
      ("${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr/local")))
 


### PR DESCRIPTION
Python site-package / dist-package rule is the same for debian. Has to be fixed to use this script to also generate python debian packages. There is another check for Ubuntu in Line 109, I am not sure if this is also needed for debian. 