### PR TITLE
Revert "Drop check for boost-numpy"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,8 @@ find_package(PythonLibs ${py_major_release_num} REQUIRED)
 find_package(Boost REQUIRED) # hack to get Boost_VERSION_STRING populated
 get_boost_python_component_name(PYTHONLIBS_VERSION_STRING Boost_VERSION_STRING boost_python boost_numpy)
 message("Boost Python aka ${boost_python} ")
-find_package(Boost REQUIRED COMPONENTS ${boost_python})
+message("Boost Numpy aka ${boost_numpy} ")
+find_package(Boost REQUIRED COMPONENTS ${boost_python} ${boost_numpy})
 
 # find_package(NumPy REQUIRED)
 find_package(ChimeraTK-DeviceAccess ${min_req_chimeratk_version} REQUIRED)
@@ -117,7 +118,7 @@ target_link_libraries(${boost_python_core_module} ${TSAN_LIBS}
   ${PYTHON_LIBRARIES}
   ${Boost_LIBRARIES}
   Boost::${boost_python}
-  ${TSAN_LIBS})
+  Boost::${boost_numpy} ${TSAN_LIBS})
 
 #
 # Generate boost test executable

--- a/cmake/Modules/pythonBindingHelperMacros.cmake
+++ b/cmake/Modules/pythonBindingHelperMacros.cmake
@@ -100,13 +100,14 @@ function(get_python_module_install_path python_version_string install_path)
     
 endfunction()
 
-function (get_boost_python_component_name pythonlib_version boost_version python_component_name)
+function (get_boost_python_component_name pythonlib_version boost_version python_component_name numpy_component_name)
 
     convert_version_string_to_list(${pythonlib_version} version_list)
     list(GET version_list 0 py_major_version)
     list(GET version_list 1 py_minor_version)
 
     set(${python_component_name} "python${py_major_version}${py_minor_version}" PARENT_SCOPE)
+    set(${numpy_component_name} "numpy${py_major_version}${py_minor_version}" PARENT_SCOPE)
 
 endfunction()
 


### PR DESCRIPTION
This reverts commit 02fe5e953b6eddde58737340dede267ee8279691.

Sorry, this was wrong. Boost(-Python) is horribly broken