### PR TITLE
Make NUMPY INCLUDES a cached variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ INCLUDE(${CMAKE_SOURCE_DIR}/cmake/set_default_flags.cmake)
 # numpy v1.7's documentation.
 add_definitions(-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION)
 
+set(NUMPY_INCLUDE_DIRS "" CACHE PATH "Additional NUMPY include path")
 #
 # Set header file locations
 include_directories(SYSTEM ${Boost_INCLUDE_DIR}


### PR DESCRIPTION
So it is from the outside by passing it to CMake via -D