### PR TITLE
deactive tsan asan tests in jenkins pipeline

### DIFF
--- a/.jenkinsfile
+++ b/.jenkinsfile
@@ -1,3 +1,8 @@
 @Library('ChimeraTK') _
 env.CMAKE_EXTRA_ARGS="-DPYTHON3=True"
-autojob(['ChimeraTK/DeviceAccess'], 'https://github.com/ChimeraTK/DeviceAccess-PythonBindings')
+autojob(['ChimeraTK/DeviceAccess'], 'https://github.com/ChimeraTK/DeviceAccess-PythonBindings', ['focal-Debug',
+                                   'focal-Release',
+                                  // 'focal-tsan', // Unless Python is not recompiled with tsan/asan capabilities
+                                  // 'focal-asan', // it is thus not useful to check modules for the bindings
+                                   'tumbleweed-Debug',
+                                   'tumbleweed-Release'])


### PR DESCRIPTION
For a real check Python would have to be compiled for asan and tsan checks. This would still produce many false positves and is not stable (https://tobywf.com/2021/02/python-ext-asan/)

As long as the bindings are only used for limited periods, memory leaks should be insubstantial.