### PR TITLE
fix(deviceaccess): Fix for register overflow (issue #48)

### DIFF
--- a/deviceaccess.py
+++ b/deviceaccess.py
@@ -1216,7 +1216,6 @@ class Device:
 
         catalogue = self.getRegisterCatalogue()
         register = catalogue.getRegister(registerPath)
-        numberOfElements = register.getNumberOfElements() - wordOffsetInRegister
         # make proper array, if number was submitted
         if isinstance(dataToWrite, list):
             array = np.array(dataToWrite)
@@ -1229,5 +1228,5 @@ class Device:
             array = dataToWrite
 
         accessModeFlags = [] if accessModeFlags is None else accessModeFlags
-        self._device.write(array, registerPath, numberOfElements,
+        self._device.write(array, registerPath, array.size,
                            wordOffsetInRegister, accessModeFlags)


### PR DESCRIPTION
A fix for the problem, which makes device access unusable for init scripts. Tested with 1D arrays.