### PR TITLE
feat: improve register catalogue

### DIFF
--- a/deviceaccess.py
+++ b/deviceaccess.py
@@ -1434,6 +1434,27 @@ class Device:
 
 
 #######################################################################################################################
+# Middle Layer Class extensions, might be unnecessary in the future with a switch from boost to pybind11
+
+class RegisterClassIterator:
+    def __init__(self, registerCatalogue):
+        self._rc = registerCatalogue
+        self._index = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if len(self._rc._items()) > self._index:
+            self._index += 1
+            return self._rc._items()[self._index-1]
+        else:
+            raise StopIteration
+
+pb.RegisterCatalogue.__iter__ = lambda rc: RegisterClassIterator(rc)
+
+
+#######################################################################################################################
 # Type Definitions
 
 

--- a/include/RegisterCatalogue.h
+++ b/include/RegisterCatalogue.h
@@ -17,6 +17,7 @@ namespace DeviceAccessPython {
    public:
     static bool hasRegister(ChimeraTK::RegisterCatalogue& self, const std::string& registerPathName);
     static ChimeraTK::RegisterInfo getRegister(ChimeraTK::RegisterCatalogue& self, const std::string& registerPathName);
+    static boost::python::list items(ChimeraTK::RegisterCatalogue& self);
   };
 
   /*****************************************************************************************************************/

--- a/src/RegisterCatalogue.cc
+++ b/src/RegisterCatalogue.cc
@@ -22,6 +22,15 @@ namespace DeviceAccessPython {
 
   /*******************************************************************************************************************/
 
+    boost::python::list RegisterCatalogue::items(ChimeraTK::RegisterCatalogue& self) {
+    boost::python::list registerInfos{};
+    for(const auto &regInfo : self)
+      registerInfos.append(ChimeraTK::RegisterInfo(regInfo.clone()));
+    return registerInfos;
+  }
+
+  /*******************************************************************************************************************/
+
   std::string RegisterInfo::getRegisterName(ChimeraTK::RegisterInfo& self) {
     return self.getRegisterName();
   }

--- a/src/deviceaccessPython.cc
+++ b/src/deviceaccessPython.cc
@@ -142,9 +142,7 @@ BOOST_PYTHON_MODULE(_da_python_bindings) {
   bp::def("getDmapFile", DeviceAccessPython::getDmapFile);
 
   bp::class_<ChimeraTK::RegisterCatalogue>("RegisterCatalogue", bp::init<ChimeraTK::RegisterCatalogue>())
-      //.def("__iter__", bp::range(&ChimeraTK::RegisterCatalogue::begin, &ChimeraTK::RegisterCatalogue::end)) // TODO:
-      // if someone needs to iterate through the register.
-      // fix iteration implementation
+      .def("_items", DeviceAccessPython::RegisterCatalogue::items)
       .def("hasRegister", DeviceAccessPython::RegisterCatalogue::hasRegister)
       .def("getRegister", DeviceAccessPython::RegisterCatalogue::getRegister);
 

--- a/tests/testRegisterCatalogue.py
+++ b/tests/testRegisterCatalogue.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Deutsches Elektronen-Synchrotron DESY, MSK, ChimeraTK Project <chimeratk-support@desy.de>
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+from concurrent.futures import thread
+import sys
+import unittest
+import numpy as np
+import os
+import threading
+from time import sleep
+
+
+# fmt: off
+# This is a hack for nw. What this does is, add the build directory to python's
+# path, so that it can find the deviceaccess module. Formatting is switched off,
+# so the import is not sorted into the others.
+sys.path.insert(0, os.path.abspath(os.path.join(os.curdir,"..")))
+import deviceaccess as da
+# fmt: on
+
+
+class TestRegisterCatalogue(unittest.TestCase):
+
+    def setUp(self):
+        da.setDMapFilePath("deviceInformation/push.dmap")
+        self.dev = da.Device("SHARED_RAW_DEVICE")
+
+    def tearDown(self) -> None:
+        pass
+
+    def testIterator(self):
+        # Test to see if the iterator function works in a for loop
+        rc = self.dev.getRegisterCatalogue()
+        registers_in_num_dev = ['/BOARD/WORD_FIRMWARE',
+                                '/BOARD/WORD_COMPILATION',
+                                '/APP0/WORD_STATUS',
+                                '/APP0/WORD_SCRATCH',
+                                '/APP0/MODULE0',
+                                '/APP0/MODULE1',
+                                '/MODULE0/WORD_USER1',
+                                '/MODULE0/WORD_USER2',
+                                '/MODULE1/WORD_USER1',
+                                '/MODULE1/WORD_USER2',
+                                '/MODULE1/TEST_AREA',
+                                '/MODULE1/TEST_AREA_PUSH',
+                                '/MODULE1/DATA_READY']
+        element_counter = 0
+        for i, iterated_register in enumerate(rc):
+            # should not have more elements
+            self.assertTrue(i < len(registers_in_num_dev))
+            # should list same names
+            self.assertEqual(iterated_register.getRegisterName(), registers_in_num_dev[i])
+            element_counter += 1
+
+        # should not have fewer elements
+        self.assertEqual(element_counter, len(registers_in_num_dev))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Added an _items() function to the middle-layer.
Top-layer translates this to a standard Python iterator.

This might be subject to change when boost lib is switched to pybind11.