### PR TITLE
fix: make python classes/enums local

### DIFF
--- a/src/PyDataConsistencyGroup.cc
+++ b/src/PyDataConsistencyGroup.cc
@@ -21,7 +21,7 @@ namespace ChimeraTK {
   /********************************************************************************************************************/
 
   void PyDataConsistencyGroup::bind(py::module& m) {
-    py::class_<ctk::DataConsistencyGroup>(m, "DataConsistencyGroup")
+    py::class_<ctk::DataConsistencyGroup>(m, "DataConsistencyGroup", py::module_local())
         .def(py::init<ctk::DataConsistencyGroup::MatchingMode>())
         .def(
             "add", [](ctk::DataConsistencyGroup& self, PyTransferElementBase& element) { self.add(element.getTE()); },
@@ -41,7 +41,7 @@ namespace ChimeraTK {
 
   void PyMatchingMode::bind(py::module& m) {
     py::enum_<ctk::DataConsistencyGroup::MatchingMode>(
-        m, "MatchingMode", "Enum describing the matching mode of a DataConsistencyGroup.")
+        m, "MatchingMode", py::module_local(), "Enum describing the matching mode of a DataConsistencyGroup.")
         .value("none", ctk::DataConsistencyGroup::MatchingMode::none,
             "No matching, effectively disable the DataConsitencyGroup. update() will always return true. ")
         .value("exact", ctk::DataConsistencyGroup::MatchingMode::exact,

--- a/src/PyDataType.cc
+++ b/src/PyDataType.cc
@@ -15,7 +15,8 @@ namespace ChimeraTK {
     py::class_<ChimeraTK::DataType> mDataType(mod, "DataType",
         R"(The actual enum representing the data type.
           It is a plain enum so the data type class can be used like a class enum,
-          i.e. types are identified for instance as DataType::int32.)");
+          i.e. types are identified for instance as DataType::int32.)",
+        py::module_local());
     mDataType.def(py::init<ChimeraTK::DataType::TheType>())
         .def("__str__", &ChimeraTK::DataType::getAsString)
         .def("__repr__", [](const ChimeraTK::DataType& type) { return "DataType." + type.getAsString(); })
@@ -40,7 +41,7 @@ namespace ChimeraTK {
               :return: True if the data type is signed, false otherwise.
               :rtype: bool)");
 
-    py::enum_<ChimeraTK::DataType::TheType>(mDataType, "TheType")
+    py::enum_<ChimeraTK::DataType::TheType>(mDataType, "TheType", py::module_local())
         .value("none", ChimeraTK::DataType::none,
             "The data type/concept does not exist, e.g. there is no raw transfer (do not confuse with Void)")
         .value("int8", ChimeraTK::DataType::int8)

--- a/src/PyDevice.cc
+++ b/src/PyDevice.cc
@@ -212,7 +212,8 @@ namespace ChimeraTK {
 
       The device can be opened and closed, and provides methods to obtain register accessors. Additionally,
       convenience methods to read and write registers directly are provided.
-      The class also offers methods to check the device state, obtain the register catalogue,  Metadata and to set exception conditions.)");
+      The class also offers methods to check the device state, obtain the register catalogue,  Metadata and to set exception conditions.)",
+        py::module_local());
 
     dev.def(py::init<const std::string&>(), py::arg("aliasName"),
            R"(Initialize device and associate a backend.

--- a/src/PyOneDRegisterAccessor.cc
+++ b/src/PyOneDRegisterAccessor.cc
@@ -179,7 +179,7 @@ namespace ChimeraTK {
         Note:
             Transfers between the device and the internal buffer need to be triggered using the read() and
             write() functions before reading from resp. after writing to the buffer.)",
-        py::buffer_protocol());
+        py::buffer_protocol(), py::module_local());
 
     arrayacc.def(py::init<>())
         .def_buffer(&PyOneDRegisterAccessor::getBufferInfo)

--- a/src/PyReadAnyGroup.cc
+++ b/src/PyReadAnyGroup.cc
@@ -21,7 +21,7 @@ namespace ChimeraTK {
   /********************************************************************************************************************/
 
   void PyReadAnyGroup::bind(py::module& m) {
-    py::class_<ctk::ReadAnyGroup>(m, "ReadAnyGroup")
+    py::class_<ctk::ReadAnyGroup>(m, "ReadAnyGroup", py::module_local())
         .def(py::init<>())
         .def("finalise", &ctk::ReadAnyGroup::finalise,
             R"(Finalise the group. After this, add() may no longer be called and read methods may be used.)")
@@ -85,7 +85,7 @@ namespace ChimeraTK {
   /*******************************************************************************************************************/
 
   void PyReadAnyGroupNotification::bind(py::module& m) {
-    py::class_<ctk::ReadAnyGroup::Notification>(m, "Notification")
+    py::class_<ctk::ReadAnyGroup::Notification>(m, "Notification", py::module_local())
         .def(py::init<>())
         .def("accept", &ctk::ReadAnyGroup::Notification::accept, R"(Accept the notification.)")
         .def("getId", &ctk::ReadAnyGroup::Notification::getId,

--- a/src/PyScalarRegisterAccessor.cc
+++ b/src/PyScalarRegisterAccessor.cc
@@ -242,7 +242,7 @@ namespace ChimeraTK {
         Note:
             Transfers between the device and the internal buffer need to be triggered using the read() and
             write() functions before reading from resp. after writing to the buffer.)",
-        py::buffer_protocol());
+        py::buffer_protocol(), py::module_local());
 
     scalaracc.def(py::init<>())
         .def("read", &PyScalarRegisterAccessor::read,

--- a/src/PyTransferElement.cc
+++ b/src/PyTransferElement.cc
@@ -10,7 +10,7 @@ namespace ChimeraTK {
   /********************************************************************************************************************/
 
   void PyTransferElementBase::bind(py::module& mod) {
-    py::class_<PyTransferElementBase>(mod, "TransferElementBase");
+    py::class_<PyTransferElementBase>(mod, "TransferElementBase", py::module_local());
   }
 
   /********************************************************************************************************************/

--- a/src/PyTransferGroup.cc
+++ b/src/PyTransferGroup.cc
@@ -21,7 +21,7 @@ namespace ChimeraTK {
   /********************************************************************************************************************/
 
   void PyTransferGroup::bind(py::module& m) {
-    py::class_<ctk::TransferGroup>(m, "TransferGroup")
+    py::class_<ctk::TransferGroup>(m, "TransferGroup", py::module_local())
         .def(py::init<>())
         .def(
             "addAccessor",

--- a/src/PyTwoDRegisterAccessor.cc
+++ b/src/PyTwoDRegisterAccessor.cc
@@ -305,7 +305,7 @@ namespace ChimeraTK {
       Note:
         Create instances via Device.getTwoDRegisterAccessor(). Transfers between the device and the internal buffer
         need to be triggered using read() and write() before reading from or after writing to the buffer.)",
-        py::buffer_protocol());
+        py::buffer_protocol(), py::module_local());
     arrayacc.def(py::init<>())
         .def_buffer(&PyTwoDRegisterAccessor::getBufferInfo)
         .def("read", &PyTwoDRegisterAccessor::read,

--- a/src/PyVersionNumber.cc
+++ b/src/PyVersionNumber.cc
@@ -34,7 +34,7 @@ namespace ChimeraTK {
   /********************************************************************************************************************/
 
   void PyVersionNumber::bind(py::module& m) {
-    py::class_<ChimeraTK::VersionNumber>(m, "VersionNumberBase")
+    py::class_<ChimeraTK::VersionNumber>(m, "VersionNumberBase", py::module_local())
         .def(
             "getVersionNumberAsString",
             [](const VersionNumber& self) -> std::string {
@@ -54,7 +54,8 @@ namespace ChimeraTK {
       example, they can help in breaking an infinite update loop that might occur when two process variables are
       related and update each other.
 
-      They are also used to determine the order of updates made to different process variables.)")
+      They are also used to determine the order of updates made to different process variables.)",
+        py::module_local())
         .def(py::init<>())
         .def("getNullVersion", &PyVersionNumber::getNullVersion,
             R"(Get a VersionNumber which is not set (null version).

--- a/src/PyVoidRegisterAccessor.cc
+++ b/src/PyVoidRegisterAccessor.cc
@@ -55,7 +55,7 @@ namespace ChimeraTK {
   /********************************************************************************************************************/
 
   void PyVoidRegisterAccessor::bind(py::module& m) {
-    py::class_<PyVoidRegisterAccessor>(m, "VoidRegisterAccessor",
+    py::class_<PyVoidRegisterAccessor>(m, "VoidRegisterAccessor", py::module_local(),
         R"(Special accessor that represents a register with no user data (ChimeraTK::Void).
 
         This accessor is typically used to model triggers or actions that do not carry a payload. There is no user

--- a/src/RegisterCatalogue.cc
+++ b/src/RegisterCatalogue.cc
@@ -33,7 +33,7 @@ namespace DeviceAccessPython {
   /*******************************************************************************************************************/
 
   void RegisterCatalogue::bind(py::module& m) {
-    py::class_<ChimeraTK::RegisterCatalogue>(m, "RegisterCatalogue")
+    py::class_<ChimeraTK::RegisterCatalogue>(m, "RegisterCatalogue", py::module_local())
         .def(py::init<ChimeraTK::RegisterCatalogue>(), "Catalogue of register information.")
         .def(
             "__iter__", [](const ChimeraTK::RegisterCatalogue& s) { return py::make_iterator(s.begin(), s.end()); },
@@ -92,7 +92,7 @@ namespace DeviceAccessPython {
   }
 
   void RegisterInfo::bind(py::module& m) {
-    py::class_<ChimeraTK::RegisterInfo>(m, "RegisterInfo")
+    py::class_<ChimeraTK::RegisterInfo>(m, "RegisterInfo", py::module_local())
         .def(py::init<ChimeraTK::RegisterInfo>(), "Catalogue of register information.")
         .def("getDataDescriptor", DeviceAccessPython::RegisterInfo::getDataDescriptor,
             R"(Return description of the actual payload data for this register.
@@ -156,7 +156,7 @@ namespace DeviceAccessPython {
   /*******************************************************************************************************************/
 
   void RegisterInfo::bindBackendRegisterInfoBase(py::module& m) {
-    py::class_<ChimeraTK::BackendRegisterInfoBase>(m, "BackendRegisterInfoBase")
+    py::class_<ChimeraTK::BackendRegisterInfoBase>(m, "BackendRegisterInfoBase", py::module_local())
         .def("getDataDescriptor", &ChimeraTK::BackendRegisterInfoBase::getDataDescriptor,
             R"(Return description of the actual payload data for this register.
 
@@ -229,7 +229,7 @@ namespace DeviceAccessPython {
   /*******************************************************************************************************************/
 
   void DataDescriptor::bind(py::module& m) {
-    py::class_<ChimeraTK::DataDescriptor>(m, "DataDescriptor")
+    py::class_<ChimeraTK::DataDescriptor>(m, "DataDescriptor", py::module_local())
         .def(py::init<ChimeraTK::DataDescriptor>())
         .def(py::init<ChimeraTK::DataType>(),
             R"(Construct a DataDescriptor from a DataType object.

--- a/src/deviceaccessPython.cc
+++ b/src/deviceaccessPython.cc
@@ -59,7 +59,7 @@ PYBIND11_MODULE(deviceaccess, m) {
         :return: Path of the dmap file (directory and file name).
         :rtype: str)");
 
-  py::enum_<ChimeraTK::AccessMode>(m, "AccessMode",
+  py::enum_<ChimeraTK::AccessMode>(m, "AccessMode", py::module_local(),
       R"(Access mode flags for register access.
 
         Note:
@@ -70,7 +70,7 @@ PYBIND11_MODULE(deviceaccess, m) {
           R"(This access mode makes any read blocking until new data has arrived since the last read. This flag may not be supported by all registers (and backends), in which case an exception will be thrown.)")
       .export_values();
 
-  py::enum_<ChimeraTK::DataDescriptor::FundamentalType>(m, "FundamentalType",
+  py::enum_<ChimeraTK::DataDescriptor::FundamentalType>(m, "FundamentalType", py::module_local(),
       "This is only used inside the DataDescriptor class; defined outside to prevent too long fully qualified names.")
       .value("numeric", ChimeraTK::DataDescriptor::FundamentalType::numeric)
       .value("string", ChimeraTK::DataDescriptor::FundamentalType::string)
@@ -79,7 +79,7 @@ PYBIND11_MODULE(deviceaccess, m) {
       .value("undefined", ChimeraTK::DataDescriptor::FundamentalType::undefined)
       .export_values();
 
-  py::enum_<ChimeraTK::DataValidity>(m, "DataValidity",
+  py::enum_<ChimeraTK::DataValidity>(m, "DataValidity", py::module_local(),
       R"(The current state of the data.
 
         Note:
@@ -92,7 +92,7 @@ PYBIND11_MODULE(deviceaccess, m) {
       .value("faulty", ChimeraTK::DataValidity::faulty, "The data is not considered valid")
       .export_values();
 
-  py::class_<ChimeraTK::TransferElementID>(m, "TransferElementID")
+  py::class_<ChimeraTK::TransferElementID>(m, "TransferElementID", py::module_local())
       .def("isValid", &ChimeraTK::TransferElementID::isValid, "Check whether the ID is valid.")
       .def("__ne__", &ChimeraTK::TransferElementID::operator!=)
       .def("__hash__",
@@ -100,7 +100,8 @@ PYBIND11_MODULE(deviceaccess, m) {
       .def("__eq__", &ChimeraTK::TransferElementID::operator==);
 
   py::class_<ChimeraTK::RegisterPath>(m, "RegisterPath",
-      R"a(Class to store a register path name. Elements of the path are separated by a "/" character, but an  separation character (e.g. ".") can optionally be specified as well. Different equivalent notations will be converted into a standardised notation automatically.)a")
+      R"a(Class to store a register path name. Elements of the path are separated by a "/" character, but an  separation character (e.g. ".") can optionally be specified as well. Different equivalent notations will be converted into a standardised notation automatically.)a",
+      py::module_local())
       .def(py::init<ChimeraTK::RegisterPath>())
       .def(py::init<const std::string&>(), py::arg("path"))
       .def("__str__", &ChimeraTK::RegisterPath::operator std::string)


### PR DESCRIPTION
This way we can import deviceaccess and PyApplocationCore simultaneously.